### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/PostalCode/Get.php
+++ b/api/v3/PostalCode/Get.php
@@ -43,7 +43,7 @@ function _civicrm_api3_postal_code_Get_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_postal_code_Get($params) {
   // I think a field 'id' is required, so I will just 'recycle' the postal


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.